### PR TITLE
Correction of keyspace name replacement 

### DIFF
--- a/getSnapshot
+++ b/getSnapshot
@@ -228,6 +228,7 @@
         # Create a new snapshot if a snapshot name was not provided
         printf "No snapshot name provided, creating new snapshot\n"
 
+        nodetool -h $JMXIP flush -- $KEYSPACE
         OUTPUT=$( nodetool -h $JMXIP snapshot $KEYSPACE 2>&1 )
         SNAPSHOT=$( grep -Eo '[0-9]{10}[0-9]+' <<< "$OUTPUT" | tail -1 )
 

--- a/putSnapshot
+++ b/putSnapshot
@@ -85,7 +85,7 @@
         printf "    -h,--help                          Print usage and exit\n"
         printf "    -v,--version                       Print version information and exit\n"
         printf "    -f,--file <snapshot file>          REQUIRED: The snapshot file name (created using the\n"
-        printf "                                       getSnapshot utility\n"
+        printf "                                       getSnapshot utility)\n"
         printf "    -n,--node <node address>           Destination Cassandra node IP (defaults to the local\n"
         printf "                                       Cassandra IP if run on a Cassandra node, otherwise\n"
         printf "                                       required in order to connect to Cassandra.  Will take\n"
@@ -96,6 +96,8 @@
         printf "                                       to the sourcen datacenter name)\n"
         printf "    -r,--replication <new rf>          Override the destination replication factor (defaults\n"
         printf "                                       to source replication factor)\n"
+        printf "    -t,--table-keyspace-name <boolean> Replace the original keyspace string if it appears in\n"
+        printf "                                       a table name (defaults to true)\n"
         printf "    -y,--yaml <cassandra.yaml file>    Alternate cassandra.yaml file\n"
         exit 0
     }
@@ -120,8 +122,8 @@
 # --------------------------
     # Great sample getopt implementation by Cosimo Streppone
     # https://gist.github.com/cosimo/3760587#file-parse-options-sh
-    SHORT='hvd:f:n:k:r:y:'
-    LONG='help,version,datacenter:,file:,node:,keyspace:,replication:,yaml:'
+    SHORT='hvd:f:n:k:r:t:y:'
+    LONG='help,version,datacenter:,file:,node:,keyspace:,replication:,table-keyspace-name:,yaml:'
     OPTS=$( getopt -o $SHORT --long $LONG -n "$0" -- "$@" )
 
     if [ $? -gt 0 ]; then
@@ -141,6 +143,7 @@
             -d|--datacenter) DATACENTER="$2"; shift 2;;
             -r|--replication) RFACTOR="$2"; shift 2;;
             -y|--yaml) INPYAML="$2"; shift 2;;
+            -t|--table-keyspace-name) TABLE_KEYSPACE_NAME="$2"; shift 2;;
             --) shift; break;;
             *) printf "Error processing command arguments\n" >&2; exit 1;;
         esac
@@ -254,13 +257,15 @@
     if [ ! -z $KEYSPACE ]; then
         # Update keyspace names in snapshot
         sed -i 's/\s'$FILEKSNAME'\s/ '$KEYSPACE' /g' "$SCHEMAFILE"
-        sed -i 's/\s'$FILEKSNAME\.'/ '$KEYSPACE\.'/g' "$SCHEMAFILE"
+        sed -i 's/\s'$FILEKSNAME\\.'/ '$KEYSPACE\.'/g' "$SCHEMAFILE"
         mv "${TEMPDIR}/${FILEKSNAME}" "${TEMPDIR}/${KEYSPACE}"
-        for dbfile in $( find "${TEMPDIR}/${KEYSPACE}" -type f ); do
-            if grep "${FILEKSNAME}" <<< "${dbfile}" >/dev/null; then
-                mv "$dbfile" "${dbfile//$FILEKSNAME/$KEYSPACE}"
-            fi
-        done
+        if [ "x${TABLE_KEYSPACE_NAME}" != "xfalse" ]; then
+            for dbfile in $( cd "${TEMPDIR}/${KEYSPACE}" && find . -type f ); do
+                if grep "${FILEKSNAME}" <<< "${dbfile}" >/dev/null; then
+                    echo mv "$dbfile" "${dbfile//$FILEKSNAME/$KEYSPACE}"
+                fi
+            done
+        fi
         NEWKSNAME=$KEYSPACE
     else
         NEWKSNAME=$FILEKSNAME


### PR DESCRIPTION
This PR fixes issues that the original snapshot tool has:

1. It searches and replaces the original keyspace name even the name appears in the path and are not meant to be replaced.
2. It does not match the dot literal correctly.
3. If a table name contains a string which happens to be the original keyspace name, the table name is replaced silently.

This repository solves the above problems by doing the following:

1. It searches in the current working temporary directory, so the replacement doesn't affect path.
2. It introduces a new command line argument `-t|--table-keyspace-name` to control if the string in table names should be replaced, which defaults to `true` to keep compatible with the old behavior when this argument is missing.

Fix a bug in the `sed` command that matches the literal dot which is reported in [this issue](https://github.com/AppliedInfrastructure/cassandra-snapshot-tools/issues/13).